### PR TITLE
Add last_throw_time and clarify existing attributes

### DIFF
--- a/custom_components/techdisc/sensor.py
+++ b/custom_components/techdisc/sensor.py
@@ -288,18 +288,26 @@ class TechDiscThrowTypeSensor(TechDiscSensorBase):
             return primary
         return None
 
+from homeassistant.util import dt as dt_util # Import datetime utility
+
     @property
     def extra_state_attributes(self) -> dict[str, any] | None:
         """Return additional state attributes."""
         if self.coordinator.data:
-            return {
-                "throw_time": self.coordinator.data.get("throwTime", {}).get("_seconds"),
+            attrs = {
+                "throw_time_seconds": self.coordinator.data.get("throwTime", {}).get("_seconds"), # Keep original for reference
                 "temperature": self.coordinator.data.get("temp"),
                 "bearing": self.coordinator.data.get("bearing"),
                 "uphill_angle": self.coordinator.data.get("uphillAngle"),
                 "off_axis_degrees": self.coordinator.data.get("offAxisDegrees"),
                 "estimated_flight_numbers": self.coordinator.data.get("estimatedFlightNumbers"),
                 "handedness": self.coordinator.data.get("handedness"),
-                "device_id": self.coordinator.data.get("deviceId"),
+                "device_id": self.coordinator.data.get("deviceId"), # This is deviceUid
             }
+            if hasattr(self.coordinator, 'last_throw_time_millis') and self.coordinator.last_throw_time_millis is not None:
+                last_throw_datetime = dt_util.utc_from_timestamp(self.coordinator.last_throw_time_millis / 1000)
+                attrs["last_throw_time"] = last_throw_datetime.isoformat()
+            else:
+                attrs["last_throw_time"] = None
+            return attrs
         return None


### PR DESCRIPTION
- Adds `last_throw_time` to the `TechDiscThrowTypeSensor` extra_state_attributes, providing the timestamp of the last successfully processed throw in ISO 8601 format.
- Renames the previous `throw_time` attribute to `throw_time_seconds` for clarity, as it represents raw seconds from the epoch.
- Confirms that `bearing` and `device_id` (representing `deviceUid` from the API) are already correctly exposed.